### PR TITLE
Fixes an issue where `byAdding(.extraAttributes(_:))` removes previously assigned `extraAttributes`.

### DIFF
--- a/Sources/StringStyle+Part.swift
+++ b/Sources/StringStyle+Part.swift
@@ -165,7 +165,7 @@ extension StringStyle {
     mutating func update(part stylePart: Part) {
         switch stylePart {
         case let .extraAttributes(attributes):
-            self.extraAttributes = attributes
+            self.add(extraAttributes: attributes)
         case let .font(font):
             self.font = font
         case let .link(link):

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -829,6 +829,15 @@ class StringStyleTests: XCTestCase {
         BONAssert(attributes: childAttributes, key: .foregroundColor, value: BONColor.black)
     }
 
+    func testOverridingExtraAttributesPart() {
+        let style = StringStyle()
+            .byAdding(.extraAttributes([.backgroundColor: UIColor.white]))
+            .byAdding(.extraAttributes([.foregroundColor: UIColor.black]))
+
+        BONAssert(attributes: style.attributes, key: .backgroundColor, value: UIColor.white)
+        BONAssert(attributes: style.attributes, key: .foregroundColor, value: UIColor.black)
+    }
+
 }
 
 private extension StringStyleTests {

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -831,11 +831,11 @@ class StringStyleTests: XCTestCase {
 
     func testOverridingExtraAttributesPart() {
         let style = StringStyle()
-            .byAdding(.extraAttributes([.backgroundColor: UIColor.white]))
-            .byAdding(.extraAttributes([.foregroundColor: UIColor.black]))
+            .byAdding(.extraAttributes([.backgroundColor: BONColor.white]))
+            .byAdding(.extraAttributes([.foregroundColor: BONColor.black]))
 
-        BONAssert(attributes: style.attributes, key: .backgroundColor, value: UIColor.white)
-        BONAssert(attributes: style.attributes, key: .foregroundColor, value: UIColor.black)
+        BONAssert(attributes: style.attributes, key: .backgroundColor, value: BONColor.white)
+        BONAssert(attributes: style.attributes, key: .foregroundColor, value: BONColor.black)
     }
 
 }


### PR DESCRIPTION
### Issue

`byAdding(stringStyle:)` preserves previously assigned `extraAttributes`, but `byAdding(_:)` doesn't.

```swift
let style = StringStyle()
    .byAdding(stringStyle: StringStyle(.extraAttributes([.backgroundColor: UIColor.white])))
    .byAdding(stringStyle: StringStyle(.extraAttributes([.foregroundColor: UIColor.black])))

BONAssert(attributes: style.attributes, key: .backgroundColor, value: UIColor.white) // ✅
BONAssert(attributes: style.attributes, key: .foregroundColor, value: UIColor.black) // ✅
```

```swift
let style = StringStyle()
    .byAdding(.extraAttributes([.backgroundColor: UIColor.white]))
    .byAdding(.extraAttributes([.foregroundColor: UIColor.black])) // overwrites previous line

BONAssert(attributes: style.attributes, key: .backgroundColor, value: UIColor.white) // ❌
BONAssert(attributes: style.attributes, key: .foregroundColor, value: UIColor.black) // ✅
```

### Solution
Fixed `update(part:)` method to use `add(extraAttributes:)` for `.extraAttributes(_:)`, like `byAdding(stringStyle:)` does.